### PR TITLE
Force mod order in conan exiles

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -78,7 +78,12 @@ if [ ! -z "${WS_CONTENT}" ]; then
 		touch ${SERVER_DIR}/ConanSandbox/Mods/modlist.txt
 	fi
 	echo "---Putting workshop content into modlist---"
-	find ${SERVER_DIR}/steamapps/workshop/content/ -name *.pak > ${SERVER_DIR}/ConanSandbox/Mods/modlist.txt
+	#install mods in order
+    > ${SERVER_DIR}/ConanSandbox/Mods/modlist.txt
+    for WS_ITEM in ${WS_CONTENT}; do
+    	find ${SERVER_DIR}/steamapps/workshop/content/440900/${WS_ITEM}/ -name *.pak >> ${SERVER_DIR}/ConanSandbox/Mods/modlist.txt
+    done
+
 fi
 
 echo "---Prepare Server---"


### PR DESCRIPTION
This will allow users to specify the order that mods are loaded by adding them to the modlist.txt in the same order that they are included in $WS_CONTENT. Additionally, it allows users to effectively remove mods by removing them from $WS_CONTENT