### PR TITLE
Arma 3: Use x64 executable

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -51,4 +51,4 @@ chmod -R ${DATA_PERM} ${DATA_DIR}
 
 echo "---Start Server---"
 cd ${SERVER_DIR}
-./arma3server ${GAME_PARAMS}
+./arma3server_x64 ${GAME_PARAMS}


### PR DESCRIPTION
the x32 arma 3 server has severe performance issues and should not be used anymore.