### PR TITLE
Add support for dynamically running with either UID/GID or as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir $DATA_DIR && \
 	ulimit -n 2048
 
 ADD /scripts/ /opt/scripts/
-RUN chmod -R 774 /opt/scripts/
+RUN chmod -R 775 /opt/scripts/
 
 #Server Start
 ENTRYPOINT ["/opt/scripts/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir $DATA_DIR && \
 	ulimit -n 2048
 
 ADD /scripts/ /opt/scripts/
-RUN chmod -R 770 /opt/scripts/
+RUN chmod -R 774 /opt/scripts/
 
 #Server Start
 ENTRYPOINT ["/opt/scripts/start.sh"]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -27,9 +27,6 @@ if [ "$UIDMode" == "true" ]
   chown -R root:${GID} /opt/scripts
   chmod -R 750 /opt/scripts
   chown -R ${UID}:${GID} ${DATA_DIR}
-else
-  cp -r /opt/scripts /opt/scripts
-  chmod -R 750 /opt/scripts
 fi
 
 echo "---Starting...---"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -44,7 +44,7 @@ trap 'kill ${!}; term_handler' SIGTERM
 if [ "$UIDMode" == "true" ]
   su ${USER} -c "/opt/scripts/start-server.sh" &
 else
-  /opt/scripts/run/start-server.sh
+  /opt/scripts/run/start-server.sh &
 fi
 killpid="$!"
 while true


### PR DESCRIPTION
The current container only can run using root.
Docker natively supports a user setting besides UID GID for running as non-root.

This basically means we slightly have to increase some permissions and ensure UID/GID is skipped when running as non-root