### PR TITLE
fix permission on run container as root

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 echo "---Ensuring UID: ${UID} matches user---"
-usermod -u ${UID} ${USER}
+usermod -o -u ${UID} ${USER}
 echo "---Ensuring GID: ${GID} matches user---"
-groupmod -g ${GID} ${USER} > /dev/null 2>&1 ||:
+groupmod -o -g ${GID} ${USER} > /dev/null 2>&1 ||:
 usermod -g ${GID} ${USER}
 echo "---Setting umask to ${UMASK}---"
 umask ${UMASK}


### PR DESCRIPTION
Unlike unraid, some NAS systems may choose to attribute all file permissions to the root user(such as https://www.zspace.cn/)
When the user uses UID = 0 gid = 0, he will be plagued by permission issues
Use `usermod -o groupmod -o` to fix this problem
We can see the image of LinuxServer.io choose the same solution
https://github.com/linuxServer/docker-baseImage-ubuntu/blob/7de15ca8f48828d61498DEBD80C51F491C/Cont-init.d/10-addUser#L6