### PR TITLE
feat(palworld) add ini-updater script

### DIFF
--- a/scripts/ini-updater.sh
+++ b/scripts/ini-updater.sh
@@ -14,16 +14,50 @@ set_ini_value() {
 
     echo "Setting ${key}..."
     sed -i "s|\(${key}=\)[^,]*|\1${value}|g" "${cfgFile}"
-    echo "Set to $(grep -Po "${key}=[^,]*" "${cfgFile}")"
+    echo "Set to $(get_ini_value "$key")"
 }
 
-# Check if two arguments are provided
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <key> <value>"
+get_ini_value() {
+    local key="${1}"
+
+    # Output only the value of the key
+    grep -Po "(?<=${key}=)[^,]*" "${cfgFile}"
+}
+
+# Check if the number of arguments is valid for both set and get options
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+    echo "Usage:"
+    echo "To set a value: $0 set <key> <value>"
+    echo "To get a value: $0 get <key>"
     exit 1
 fi
 
-# Call set_ini_value with command-line arguments
-set_ini_value "$1" "$2"
+# Check the option provided (set or get)
+option="$1"
+shift
 
-echo "Done!"
+case "$option" in
+    "set")
+        # Check if two arguments are provided for set option
+        if [ "$#" -ne 2 ]; then
+            echo "Usage for set option: $0 set <key> <value>"
+            exit 1
+        fi
+        set_ini_value "$@"
+        ;;
+    "get")
+        # Check if one argument is provided for get option
+        if [ "$#" -ne 1 ]; then
+            echo "Usage for get option: $0 get <key>"
+            exit 1
+        fi
+        get_ini_value "$1"
+        ;;
+    *)
+        echo "Invalid option: $option"
+        echo "Usage:"
+        echo "To set a value: $0 set <key> <value>"
+        echo "To get a value: $0 get <key>"
+        exit 1
+        ;;
+esac

--- a/scripts/ini-updater.sh
+++ b/scripts/ini-updater.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+cfgFile=${SERVER_DIR}/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+
+set_ini_value() {
+    local key="${1}"
+    local value="${2}"
+
+    # Check if the value contains spaces or special characters
+    if [[ "$value" =~ [[:space:]] || "$value" =~ [^a-zA-Z0-9_.-] ]]; then
+        # Add quotes around the value
+        value="\"$value\""
+    fi
+
+    echo "Setting ${key}..."
+    sed -i "s|\(${key}=\)[^,]*|\1${value}|g" "${cfgFile}"
+    echo "Set to $(grep -Po "${key}=[^,]*" "${cfgFile}")"
+}
+
+# Check if two arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <key> <value>"
+    exit 1
+fi
+
+# Call set_ini_value with command-line arguments
+set_ini_value "$1" "$2"
+
+echo "Done!"

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -70,7 +70,7 @@ if [ -z "${PUBLIC_IP}" ]; then
     echo "---Can't get PublicIP, please set it manually in your PalWorldSettings.ini!---"
   else
     echo "---Sucessfully obtained PublicIP: ${PUBLIC_IP}, adding to PalWorldSettings.ini"
-    sed -i "s/PublicIP=\"[^\"]*\"/PublicIP=\"${PUBLIC_IP}\"/g" ${SERVER_DIR}/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    /opt/scripts/ini-updater.sh "PublicIP" "${PUBLIC_IP}"
   fi
 else
   if [ "${UPDATE_PUBLIC_IP}" == "true" ]; then
@@ -80,7 +80,7 @@ else
     else
       if [ "${PUBLIC_IP}" != "${NEW_PUBLIC_IP}" ]; then
         echo "---Changing PublicIP in PalWorldSettings.ini to: ${NEW_PUBLIC_IP}!---"
-        sed -i "s/PublicIP=\"[^\"]*\"/PublicIP=\"${NEW_PUBLIC_IP}\"/g" ${SERVER_DIR}/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+        /opt/scripts/ini-updater.sh "PublicIP" "${NEW_PUBLIC_IP}"
       else
         echo "---Nothing to do, PublicIP: ${PUBLIC_IP} still up-to-date!---"
       fi

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -62,7 +62,7 @@ else
 fi
 
 echo "---Checking if PublicIP is in place---"
-PUBLIC_IP="$(grep -o 'PublicIP="[^"]*"' ${SERVER_DIR}/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini | cut -d '"' -f2)"
+PUBLIC_IP="$(/opt/scripts/ini-updater.sh get "PublicIP")"
 if [ -z "${PUBLIC_IP}" ]; then
   echo "---No PublicIP found in PalWorldSettings.ini, trying to obtain it...---"
   PUBLIC_IP="$(wget -qO - ipv4.icanhazip.com)"
@@ -70,7 +70,7 @@ if [ -z "${PUBLIC_IP}" ]; then
     echo "---Can't get PublicIP, please set it manually in your PalWorldSettings.ini!---"
   else
     echo "---Sucessfully obtained PublicIP: ${PUBLIC_IP}, adding to PalWorldSettings.ini"
-    /opt/scripts/ini-updater.sh "PublicIP" "${PUBLIC_IP}"
+    /opt/scripts/ini-updater.sh set "PublicIP" "${PUBLIC_IP}"
   fi
 else
   if [ "${UPDATE_PUBLIC_IP}" == "true" ]; then
@@ -80,7 +80,7 @@ else
     else
       if [ "${PUBLIC_IP}" != "${NEW_PUBLIC_IP}" ]; then
         echo "---Changing PublicIP in PalWorldSettings.ini to: ${NEW_PUBLIC_IP}!---"
-        /opt/scripts/ini-updater.sh "PublicIP" "${NEW_PUBLIC_IP}"
+        /opt/scripts/ini-updater.sh set "PublicIP" "${NEW_PUBLIC_IP}"
       else
         echo "---Nothing to do, PublicIP: ${PUBLIC_IP} still up-to-date!---"
       fi


### PR DESCRIPTION
The script makes it easier to update the ini file and keeps the code in 1 section.
new variables can added and make this image more configurable without having to rewrite the sed everywhere.

the script should also be able to run within the image or scripts by running it like so.

set:
```shell
/opt/scripts/ini-updater.sh set "PublicIP" "${PUBLIC_IP}"
```

```shell
/opt/scripts/ini-updater.sh set "PublicPort" "8211"
```
get:
```shell
/opt/scripts/ini-updater.sh get "PublicIP"
```

```shell
/opt/scripts/ini-updater.sh get "PublicPort"
```

if the value contains special characters or spaces; quotes are added.

This will make containers easier to manage especially in kubernetes platform where our init containers dont need to be excessive rewriting the ini with sed.